### PR TITLE
Added option to manually change architecture.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,17 @@
           "type": "boolean",
           "default": true,
           "description": "Show architecture information in hover tooltip"
-        }
+        },
+        "memorySizeHover.architecture": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "target",
+            "x64",
+            "x32"
+          ],
+          "default": "auto",
+          "markdownDescription": "Architecture used for size calculations. `auto` uses host arch, `target` tries to read `C_Cpp.default.intelliSenseMode` and if fails fallback to host arch."
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
           ],
           "default": "auto",
           "markdownDescription": "Architecture used for size calculations. `auto` uses host arch, `target` tries to read `C_Cpp.default.intelliSenseMode` and if fails fallback to host arch."
+        }
       }
     }
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,11 @@
 import * as vscode from 'vscode';
 import { MemorySizeHoverProvider } from './hoverProvider';
+import { TypeInfoProvider } from './typeInfo';
 
 export function activate(context: vscode.ExtensionContext) {
     const provider = new MemorySizeHoverProvider();
+    const typeProvider = TypeInfoProvider.getInstance();
+
 
     // Register ONLY ONE hover provider for all C/C++ files
     const disposable = vscode.languages.registerHoverProvider(
@@ -14,8 +17,22 @@ export function activate(context: vscode.ExtensionContext) {
         ],
         provider
     );
+    
+    const configDisposable = vscode.workspace.onDidChangeConfiguration((event) => {
+        if (
+            event.affectsConfiguration('memorySizeHover.architecture') ||
+            event.affectsConfiguration('C_Cpp.default.intelliSenseMode')
+        ) {
+            typeProvider.refreshArchitecture();
+            provider.clearCache();
+        }
 
-    context.subscriptions.push(disposable);
+        if (event.affectsConfiguration('memorySizeHover.showArchitecture')) {
+            provider.clearCache();
+        }
+    });
+
+    context.subscriptions.push(disposable, configDisposable);
 }
 
 export function deactivate() {}

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -12,6 +12,10 @@ export class MemorySizeHoverProvider implements vscode.HoverProvider {
         this.structAnalyzer = new StructAnalyzer();
     }
 
+    public clearCache(): void {
+        this.structCache.clear();
+    }
+
     provideHover(
         document: vscode.TextDocument,
         position: vscode.Position,


### PR DESCRIPTION
Did this for myself but why not contribute.
Added configuration to select auto, target, x32 or x64 architecture mode. And some functions to set variables depending the mode selected. auto is the default (the same functionality as base), target tries to read some configs (this could be improved but...), and the other two are literal.
Maybe detectTargetArchitecture() function could be simplified to just   "if (mode.includes('64')" without that much comparing.